### PR TITLE
ignore google groups automatic footer

### DIFF
--- a/test/data/google_footer/first-first-reply.eml
+++ b/test/data/google_footer/first-first-reply.eml
@@ -1,0 +1,33 @@
+Date: Sat, 21 Mar 2020 15:43:59 -0700
+From: Noah Watkins <noah@email.com>
+To: dest <dest@email.com>
+Subject: Re: [PATCH v1 0/1] fixing stuff
+Message-ID: <0.0-2-noah@email.com>
+In-Reply-To: <0.0-1-dest@email.com>
+
+On Fri, Mar 20, 2020 at 07:03:37PM -0700, dest wrote:
+>On Fri, Mar 20, 2020 at 04:56:46PM -0700, Noah Watkins wrote:
+>> The following patches are available at:
+>
+>This fix is great. Thanks.
+>
+>>
+>>     git@github.com:user/repo.git branch
+>>
+>> Noah Watkins (1):
+>>   subject: line
+
+Should I submit again with a fixed commit message?
+>>
+>>  tools/commands.cc | 17 ++++++++++++-----
+>>  1 file changed, 12 insertions(+), 5 deletions(-)
+>>
+>> --
+>> 2.21.0
+>>
+>> --
+>> Some optional message.
+>> ---
+>> You received this message because you are subscribed to the Google Groups group.
+>> To unsubscribe from this group and stop receiving emails from it, send an email to x@x.com
+>> To view this discussion on the web visit https://groups.google.com/x

--- a/test/data/google_footer/first-reply.eml
+++ b/test/data/google_footer/first-reply.eml
@@ -1,0 +1,30 @@
+Date: Fri, 20 Mar 2020 19:03:37 -0700
+From: dest <dest@email.com>
+To: Noah Watkins <noah@email.com>
+Subject: Re: [PATCH v1 0/1] fixing stuff
+Message-ID: <0.0-1-dest@email.com>
+In-Reply-To: <0.0-1-noah@email.com>
+
+On Fri, Mar 20, 2020 at 04:56:46PM -0700, Noah Watkins wrote:
+> The following patches are available at:
+
+This fix is great. Thanks.
+
+> 
+>     git@github.com:user/repo.git branch
+> 
+> Noah Watkins (1):
+>   subject: line
+> 
+>  tools/commands.cc | 17 ++++++++++++-----
+>  1 file changed, 12 insertions(+), 5 deletions(-)
+> 
+> -- 
+> 2.21.0
+> 
+> --
+> Some optional message.
+> ---
+> You received this message because you are subscribed to the Google Groups group.
+> To unsubscribe from this group and stop receiving emails from it, send an email to x@x.com
+> To view this discussion on the web visit https://groups.google.com/x

--- a/test/data/google_footer/orig.eml
+++ b/test/data/google_footer/orig.eml
@@ -1,0 +1,19 @@
+From: Noah Watkins <noah@email.com>
+To: dest@email.com
+Subject: [PATCH v1 0/1] fixing stuff
+Date: Fri, 20 Mar 2020 16:56:46 -0700
+Message-Id: <0.0-1-noah@email.com>
+
+The following patches are available at:
+
+    git@github.com:user/repo.git branch
+
+Noah Watkins (1):
+  subject: line
+
+ tools/commands.cc | 17 ++++++++++++-----
+ 1 file changed, 12 insertions(+), 5 deletions(-)
+
+-- 
+2.21.0
+

--- a/test/data/google_footer/out-1reply.txt
+++ b/test/data/google_footer/out-1reply.txt
@@ -1,0 +1,15 @@
+The following patches are available at:
+[inline thread by dest <dest@email.com> at Fri, 20 Mar 2020 19:03:37 -0700]
+| This fix is great. Thanks.
+
+    git@github.com:user/repo.git branch
+
+Noah Watkins (1):
+  subject: line
+
+ tools/commands.cc | 17 ++++++++++++-----
+ 1 file changed, 12 insertions(+), 5 deletions(-)
+
+-- 
+2.21.0
+

--- a/test/test_parse.py
+++ b/test/test_parse.py
@@ -51,5 +51,13 @@ class ParseTestCase(unittest.TestCase):
 
 		self.assertEqual(got, want)
 
+	def test_google_footer_reply(self):
+		patch = self._load_msg_from_file("google_footer/orig.eml")
+		reply1 = self._load_msg_from_file("google_footer/first-reply.eml")
+		thread = emailthreads.parse([patch, reply1])
+		got = self._normalize(str(thread))
+		want = self._read_file("google_footer/out-1reply.txt")
+		self.assertEqual(got, want)
+
 if __name__ == '__main__':
 	unittest.main()


### PR DESCRIPTION
Hi, awesome library.

This pull request adds support for ignoring the automatic footer that google groups attaches to emails that it relays to subscribers.

I've included one test for the single reply case with these email:

    test/data/google_footer/orig.eml
    test/data/google_footer/first-reply.eml

But, I cannot seem to get the nested reply case working where there is an additional reply to first reply:
    
    test/data/google_footer/orig.eml
    test/data/google_footer/first-reply.eml
    test/data/google_footer/first-first-reply.eml

In this last case the second reply gets rendered as a standalone email instead of as a nested reply.

Any help getting this last, more general case working would be greatly appreciated and I'd submit a new PR that supports it.